### PR TITLE
x86_64 arch release now uses the amd64 suffix.

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,7 +40,7 @@ download_release() {
   case $(uname -s) in
   Linux)
     case $(uname -m) in
-    x86_64) suffix="-linux" ;;
+    x86_64) suffix="-linux-amd64" ;;
     arm64) suffix="-linux-arm64" ;;
     armv7l) suffix="-linux-arm-v7" ;;
     armv5l) suffix="-linux-arm-v5" ;;


### PR DESCRIPTION
Since release 5.1.0 the x86_64 arch release binaries have the amd64 suffix.
See https://github.com/sclevine/yj/releases/tag/v5.1.0